### PR TITLE
update riscv tap in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ First, install homebrew:
 
 Get this tap:
 
-    $ brew tap riscv-software-src/riscv
+    $ brew tap jimfangx/riscv
 
 Build the toolchain:
 


### PR DESCRIPTION
README contains an incorrect command for the tap for riscv.